### PR TITLE
Fix compilation for Swift when using Cocoapods

### DIFF
--- a/PDKTZipArchive.podspec
+++ b/PDKTZipArchive.podspec
@@ -9,7 +9,8 @@ Pod::Spec.new do |s|
   s.source       = { :git => 'https://github.com/Produkt/PDKTZipArchive.git', :tag => "v#{s.version}" }
   s.ios.deployment_target = '4.0'
   s.osx.deployment_target = '10.6'
-  s.source_files = 'PDKTZipArchive/*', 'PDKTZipArchive/minizip/*'
+  s.source_files = 'PDKTZipArchive/*.{h,m}', 'PDKTZipArchive/minizip/*.{h,c}'
+  s.public_header_files = 'PDKTZipArchive/PDKTZipArchive.h'
   s.library = 'z'
   s.requires_arc = true
 end

--- a/PDKTZipArchive.podspec
+++ b/PDKTZipArchive.podspec
@@ -9,6 +9,7 @@ Pod::Spec.new do |s|
   s.source       = { :git => 'https://github.com/Produkt/PDKTZipArchive.git', :tag => "v#{s.version}" }
   s.ios.deployment_target = '4.0'
   s.osx.deployment_target = '10.6'
+  s.tvos.deployment_target = '9.0'
   s.source_files = 'PDKTZipArchive/*.{h,m}', 'PDKTZipArchive/minizip/*.{h,c}'
   s.public_header_files = 'PDKTZipArchive/PDKTZipArchive.h'
   s.library = 'z'

--- a/PDKTZipArchive/PDKTZipArchive.h
+++ b/PDKTZipArchive/PDKTZipArchive.h
@@ -15,6 +15,9 @@
 typedef struct unz_file_info_s unz_file_info_h;
 typedef struct unz_global_info_s unz_global_info_h;
 
+typedef void(^PDKTZipProgressHandler)(NSString *entry, unz_file_info_h zipInfo, long entryNumber, long total);
+typedef void(^PDKTZipCompletionHandler)(NSString *path, BOOL succeeded, NSError *error);
+
 @protocol PDKTZipArchiveDelegate;
 
 @interface PDKTZipArchive : NSObject
@@ -27,16 +30,24 @@ typedef struct unz_global_info_s unz_global_info_h;
 + (BOOL)unzipFileAtPath:(NSString *)path toDestination:(NSString *)destination overwrite:(BOOL)overwrite password:(NSString *)password error:(NSError **)error delegate:(id<PDKTZipArchiveDelegate>)delegate;
 
 + (BOOL)unzipFileAtPath:(NSString *)path
-		  toDestination:(NSString *)destination
-		progressHandler:(void (^)(NSString *entry, unz_file_info_h zipInfo, long entryNumber, long total))progressHandler
-	  completionHandler:(void (^)(NSString *path, BOOL succeeded, NSError *error))completionHandler;
+          toDestination:(NSString *)destination
+        progressHandler:(PDKTZipProgressHandler)progressHandler
+      completionHandler:(PDKTZipCompletionHandler)completionHandler;
 
 + (BOOL)unzipFileAtPath:(NSString *)path
-		  toDestination:(NSString *)destination
-			  overwrite:(BOOL)overwrite
-			   password:(NSString *)password
-		progressHandler:(void (^)(NSString *entry, unz_file_info_h zipInfo, long entryNumber, long total))progressHandler
-	  completionHandler:(void (^)(NSString *path, BOOL succeeded, NSError *error))completionHandler;
+          toDestination:(NSString *)destination
+              overwrite:(BOOL)overwrite
+               password:(NSString *)password
+        progressHandler:(PDKTZipProgressHandler)progressHandler
+      completionHandler:(PDKTZipCompletionHandler)completionHandler;
+
+// Swift compatible versions
++ (BOOL)unzipFileAtPath:(NSString *)path
+          toDestination:(NSString *)destination
+              overwrite:(BOOL)overwrite
+               password:(NSString *)password
+               delegate:(id<PDKTZipArchiveDelegate>)delegate
+                  error:(NSError **)error;
 
 // Zip
 + (BOOL)createZipFileAtPath:(NSString *)path withFilesAtPaths:(NSArray *)filenames;

--- a/PDKTZipArchive/PDKTZipArchive.h
+++ b/PDKTZipArchive/PDKTZipArchive.h
@@ -11,7 +11,9 @@
 #define _PDKTZipArchive_H
 
 #import <Foundation/Foundation.h>
-#include "unzip.h"
+
+typedef struct unz_file_info_s unz_file_info_h;
+typedef struct unz_global_info_s unz_global_info_h;
 
 @protocol PDKTZipArchiveDelegate;
 
@@ -26,14 +28,14 @@
 
 + (BOOL)unzipFileAtPath:(NSString *)path
 		  toDestination:(NSString *)destination
-		progressHandler:(void (^)(NSString *entry, unz_file_info zipInfo, long entryNumber, long total))progressHandler
+		progressHandler:(void (^)(NSString *entry, unz_file_info_h zipInfo, long entryNumber, long total))progressHandler
 	  completionHandler:(void (^)(NSString *path, BOOL succeeded, NSError *error))completionHandler;
 
 + (BOOL)unzipFileAtPath:(NSString *)path
 		  toDestination:(NSString *)destination
 			  overwrite:(BOOL)overwrite
 			   password:(NSString *)password
-		progressHandler:(void (^)(NSString *entry, unz_file_info zipInfo, long entryNumber, long total))progressHandler
+		progressHandler:(void (^)(NSString *entry, unz_file_info_h zipInfo, long entryNumber, long total))progressHandler
 	  completionHandler:(void (^)(NSString *path, BOOL succeeded, NSError *error))completionHandler;
 
 // Zip
@@ -54,12 +56,12 @@
 
 @optional
 
-- (void)zipArchiveWillUnzipArchiveAtPath:(NSString *)path zipInfo:(unz_global_info)zipInfo;
-- (void)zipArchiveDidUnzipArchiveAtPath:(NSString *)path zipInfo:(unz_global_info)zipInfo unzippedPath:(NSString *)unzippedPath;
+- (void)zipArchiveWillUnzipArchiveAtPath:(NSString *)path zipInfo:(unz_global_info_h)zipInfo;
+- (void)zipArchiveDidUnzipArchiveAtPath:(NSString *)path zipInfo:(unz_global_info_h)zipInfo unzippedPath:(NSString *)unzippedPath;
 
-- (BOOL)zipArchiveShouldUnzipFileAtIndex:(NSInteger)fileIndex totalFiles:(NSInteger)totalFiles archivePath:(NSString *)archivePath fileInfo:(unz_file_info)fileInfo;
-- (void)zipArchiveWillUnzipFileAtIndex:(NSInteger)fileIndex totalFiles:(NSInteger)totalFiles archivePath:(NSString *)archivePath fileInfo:(unz_file_info)fileInfo;
-- (void)zipArchiveDidUnzipFileAtIndex:(NSInteger)fileIndex totalFiles:(NSInteger)totalFiles archivePath:(NSString *)archivePath fileInfo:(unz_file_info)fileInfo;
+- (BOOL)zipArchiveShouldUnzipFileAtIndex:(NSInteger)fileIndex totalFiles:(NSInteger)totalFiles archivePath:(NSString *)archivePath fileInfo:(unz_file_info_h)fileInfo;
+- (void)zipArchiveWillUnzipFileAtIndex:(NSInteger)fileIndex totalFiles:(NSInteger)totalFiles archivePath:(NSString *)archivePath fileInfo:(unz_file_info_h)fileInfo;
+- (void)zipArchiveDidUnzipFileAtIndex:(NSInteger)fileIndex totalFiles:(NSInteger)totalFiles archivePath:(NSString *)archivePath fileInfo:(unz_file_info_h)fileInfo;
 - (void)zipArchiveDidUnzipFileAtIndex:(NSInteger)fileIndex totalFiles:(NSInteger)totalFiles archivePath:(NSString *)archivePath unzippedFilePath:(NSString *)unzippedFilePath;
 
 - (void)zipArchiveProgressEvent:(NSInteger)loaded total:(NSInteger)total;

--- a/PDKTZipArchive/PDKTZipArchive.m
+++ b/PDKTZipArchive/PDKTZipArchive.m
@@ -9,6 +9,7 @@
 
 #import "PDKTZipArchive.h"
 #include "zip.h"
+#include "unzip.h"
 #import "zlib.h"
 #import "zconf.h"
 

--- a/PDKTZipArchive/PDKTZipArchive.m
+++ b/PDKTZipArchive/PDKTZipArchive.m
@@ -50,20 +50,25 @@
 	return [self unzipFileAtPath:path toDestination:destination overwrite:overwrite password:password error:error delegate:delegate progressHandler:nil completionHandler:nil];
 }
 
++ (BOOL)unzipFileAtPath:(NSString *)path toDestination:(NSString *)destination overwrite:(BOOL)overwrite password:(NSString *)password delegate:(id<PDKTZipArchiveDelegate>)delegate error:(NSError **)error
+{
+    return [self unzipFileAtPath:path toDestination:destination overwrite:overwrite password:password error:error delegate:delegate progressHandler:nil completionHandler:nil];
+}
+
 + (BOOL)unzipFileAtPath:(NSString *)path
 		  toDestination:(NSString *)destination
 			  overwrite:(BOOL)overwrite
 			   password:(NSString *)password
-		progressHandler:(void (^)(NSString *entry, unz_file_info zipInfo, long entryNumber, long total))progressHandler
-	  completionHandler:(void (^)(NSString *path, BOOL succeeded, NSError *error))completionHandler
+		progressHandler:(PDKTZipProgressHandler)progressHandler
+	  completionHandler:(PDKTZipCompletionHandler)completionHandler
 {
 	return [self unzipFileAtPath:path toDestination:destination overwrite:overwrite password:password error:nil delegate:nil progressHandler:progressHandler completionHandler:completionHandler];
 }
 
 + (BOOL)unzipFileAtPath:(NSString *)path
 		  toDestination:(NSString *)destination
-		progressHandler:(void (^)(NSString *entry, unz_file_info zipInfo, long entryNumber, long total))progressHandler
-	  completionHandler:(void (^)(NSString *path, BOOL succeeded, NSError *error))completionHandler
+		progressHandler:(PDKTZipProgressHandler)progressHandler
+	  completionHandler:(PDKTZipCompletionHandler)completionHandler
 {
 	return [self unzipFileAtPath:path toDestination:destination overwrite:YES password:nil error:nil delegate:nil progressHandler:progressHandler completionHandler:completionHandler];
 }
@@ -74,8 +79,8 @@
 			   password:(NSString *)password
 				  error:(NSError **)error
 			   delegate:(id<PDKTZipArchiveDelegate>)delegate
-		progressHandler:(void (^)(NSString *entry, unz_file_info zipInfo, long entryNumber, long total))progressHandler
-	  completionHandler:(void (^)(NSString *path, BOOL succeeded, NSError *error))completionHandler
+		progressHandler:(PDKTZipProgressHandler)progressHandler
+	  completionHandler:(PDKTZipCompletionHandler)completionHandler
 {
 	// Begin opening
 	zipFile zip = unzOpen((const char*)[path UTF8String]);

--- a/PDKTZipArchive/PDKTZipArchive.m
+++ b/PDKTZipArchive/PDKTZipArchive.m
@@ -256,9 +256,13 @@
 
 	            if (fp) {
                     if ([[[fullPath pathExtension] lowercaseString] isEqualToString:@"zip"]) {
-                        NSLog(@"Unzipping nested .zip file:  %@", [fullPath lastPathComponent]);
-                        if ([self unzipFileAtPath:fullPath toDestination:[fullPath stringByDeletingLastPathComponent] overwrite:overwrite password:password error:nil delegate:nil]) {
+                        NSError *error;
+                        NSString* nestedFilename = [fullPath lastPathComponent];
+                        NSLog(@"Unzipping nested .zip file:  %@", nestedFilename);
+                        if ([self unzipFileAtPath:fullPath toDestination:[fullPath stringByDeletingLastPathComponent] overwrite:overwrite password:password error:&error delegate:delegate]) {
                             [[NSFileManager defaultManager] removeItemAtPath:fullPath error:nil];
+                        } else {
+                            NSLog(@"Failure unzipping nested zip file: %@\n %@", nestedFilename, error.localizedDescription);
                         }
                     }
                     

--- a/Tests/PDKTZipArchiveTests.m
+++ b/Tests/PDKTZipArchiveTests.m
@@ -8,6 +8,7 @@
 //
 
 #import "PDKTZipArchive.h"
+#include "unzip.h"
 #import <XCTest/XCTest.h>
 #import <CommonCrypto/CommonDigest.h>
 


### PR DESCRIPTION
It was necessary to move the non-modular header unzip.h to the
implimentation and use typedefs for the decleration. The podspec was
changed to to include the non-necessary headers as public in the module
as well.
